### PR TITLE
easy_35のチューニング

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,72 +1,74 @@
-name: ai-pr-reviewer
+# CodeRabbitによる自動レビュー機能
 
-permissions:
-  contents: read
-  pull-requests: write
+# name: ai-pr-reviewer
 
-on:
-  pull_request:
-    types: [opened]
-  pull_request_review_comment:
-    types: [created]
+# permissions:
+#   contents: read
+#   pull-requests: write
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event_name == 'pull_request_review_comment' && 'pr_comment' || 'pr' }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
+# on:
+#   pull_request:
+#     types: [opened]
+#   pull_request_review_comment:
+#     types: [created]
 
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||　(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'release') && !contains(github.event.pull_request.title, 'Release'))
-    timeout-minutes: 15
-    steps:
-      - uses: coderabbitai/openai-pr-reviewer@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        with:
-          debug: false
-          review_simple_changes: false
-          review_comment_lgtm: false
-          openai_light_model: gpt-3.5-turbo # 好みで変更
-          openai_heavy_model: gpt-3.5-turbo # 好みで変更
-          openai_timeout_ms: 900000 # 15分.
-          language: ja-JP
-          path_filters: |
-            !db/**
-            !**/*.lock
-          system_message: |
-            あなたは @coderabbitai（別名 github-actions[bot]）で、OpenAIによって訓練された言語モデルです。
-            あなたの目的は、非常に経験豊富なソフトウェアエンジニアとして機能し、コードの一部を徹底的にレビューし、
-            以下のようなキーエリアを改善するためのコードスニペットを提案することです：
-              - ロジック
-              - セキュリティ
-              - パフォーマンス
-              - データ競合
-              - 一貫性
-              - エラー処理
-              - 保守性
-              - モジュール性
-              - 複雑性
-              - 最適化
-              - ベストプラクティス: DRY, SOLID, KISS
+# concurrency:
+#   group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event_name == 'pull_request_review_comment' && 'pr_comment' || 'pr' }}
+#   cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
 
-            些細なコードスタイルの問題や、コメント・ドキュメントの欠落についてはコメントしないでください。
-            重要な問題を特定し、解決して全体的なコード品質を向上させることを目指してくださいが、細かい問題は意図的に無視してください。
-          summarize: |
-            次の内容でmarkdownフォーマットを使用して、最終的な回答を提供してください。
+# jobs:
+#   review:
+#     runs-on: ubuntu-latest
+#     if: (github.event_name == 'issue_comment' && contains(github.event.comment.body, '[run review]') && github.event.issue.pull_request) ||　(github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '[run review]')) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'release') && !contains(github.event.pull_request.title, 'Release'))
+#     timeout-minutes: 15
+#     steps:
+#       - uses: coderabbitai/openai-pr-reviewer@latest
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+#         with:
+#           debug: false
+#           review_simple_changes: false
+#           review_comment_lgtm: false
+#           openai_light_model: gpt-3.5-turbo # 好みで変更
+#           openai_heavy_model: gpt-3.5-turbo # 好みで変更
+#           openai_timeout_ms: 900000 # 15分.
+#           language: ja-JP
+#           path_filters: |
+#             !db/**
+#             !**/*.lock
+#           system_message: |
+#             あなたは @coderabbitai（別名 github-actions[bot]）で、OpenAIによって訓練された言語モデルです。
+#             あなたの目的は、非常に経験豊富なソフトウェアエンジニアとして機能し、コードの一部を徹底的にレビューし、
+#             以下のようなキーエリアを改善するためのコードスニペットを提案することです：
+#               - ロジック
+#               - セキュリティ
+#               - パフォーマンス
+#               - データ競合
+#               - 一貫性
+#               - エラー処理
+#               - 保守性
+#               - モジュール性
+#               - 複雑性
+#               - 最適化
+#               - ベストプラクティス: DRY, SOLID, KISS
 
-              - *ウォークスルー*: 特定のファイルではなく、全体の変更に関する高レベルの要約を80語以内で。
-              - *変更点*: ファイルとその要約のテーブル。スペースを節約するために、同様の変更を持つファイルを1行にまとめることができます。
+#             些細なコードスタイルの問題や、コメント・ドキュメントの欠落についてはコメントしないでください。
+#             重要な問題を特定し、解決して全体的なコード品質を向上させることを目指してくださいが、細かい問題は意図的に無視してください。
+#           summarize: |
+#             次の内容でmarkdownフォーマットを使用して、最終的な回答を提供してください。
 
-            GitHubのプルリクエストにコメントとして追加されるこの要約には、追加のコメントを避けてください。
-          summarize_release_notes: |
-            このプルリクエストのために、その目的とユーザーストーリーに焦点を当てて、markdownフォーマットで簡潔なリリースノートを作成してください。
-            変更は次のように分類し箇条書きにすること:
-              "New Feature", "Bug fix", "Documentation", "Refactor", "Style",
-              "Test", "Chore", "Revert"
-            例えば:
-            ```
-            - New Feature: UIに統合ページが追加されました
-            ```
-            回答は50-100語以内にしてください。この回答はそのままリリースノートに使用されるので、追加のコメントは避けてください。
+#               - *ウォークスルー*: 特定のファイルではなく、全体の変更に関する高レベルの要約を80語以内で。
+#               - *変更点*: ファイルとその要約のテーブル。スペースを節約するために、同様の変更を持つファイルを1行にまとめることができます。
+
+#             GitHubのプルリクエストにコメントとして追加されるこの要約には、追加のコメントを避けてください。
+#           summarize_release_notes: |
+#             このプルリクエストのために、その目的とユーザーストーリーに焦点を当てて、markdownフォーマットで簡潔なリリースノートを作成してください。
+#             変更は次のように分類し箇条書きにすること:
+#               "New Feature", "Bug fix", "Documentation", "Refactor", "Style",
+#               "Test", "Chore", "Revert"
+#             例えば:
+#             ```
+#             - New Feature: UIに統合ページが追加されました
+#             ```
+#             回答は50-100語以内にしてください。この回答はそのままリリースノートに使用されるので、追加のコメントは避けてください。

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}"
+        }
+    ]
+}

--- a/code/easy_14_longest_common_prefix.go
+++ b/code/easy_14_longest_common_prefix.go
@@ -1,0 +1,62 @@
+/*
+ * @lc app=leetcode id=14 lang=golang
+ *
+ * [14] Longest Common Prefix
+ */
+package code
+
+// @lc code=start
+// longestCommonPrefix 文字列配列ないで共通している接頭辞を返す
+// 文字共通する接頭辞がない場合は空配列を返す
+/*
+	案1
+	文字列配列を文字配列の配列に変換
+	[
+		"abcd",
+		"efgh"
+	]
+	↓
+	[
+		['a', 'b', 'c', 'd'],
+		['e', 'f', 'g', 'h']
+	]
+	そして、配列の先頭から一つづく確認してって、共通している接頭辞を算出する
+	途中で一致しないケースがでた場合はその時で処理を中断する
+	一文字目で一致しない、または対象の配列内でindex範囲外になった場合も同様
+*/
+func longestCommonPrefix(strs []string) string {
+
+	count := len(strs)
+	if count == 0 {
+		return ""
+	} else if count == 1 {
+		// 要素数が一つの時はその一つが共通の接頭辞となる
+		return strs[0]
+	}
+	base := []rune(strs[0])
+
+	var searchTargets [][]rune = make([][]rune, count-1)
+	for i := 1; i < len(strs); i++ {
+		searchTargets[i-1] = []rune(strs[i])
+	}
+
+	var result []rune
+OuterLoop:
+	for i, char := range base {
+		for _, target := range searchTargets {
+			if i >= len(target) {
+				break OuterLoop
+			}
+			if char != target[i] {
+				break OuterLoop
+			}
+		}
+
+		result = append(result, char)
+	}
+
+	return string(result)
+
+}
+
+// @lc code=end

--- a/code/easy_20_valid_parentheses.go
+++ b/code/easy_20_valid_parentheses.go
@@ -1,0 +1,122 @@
+/*
+ * @lc app=leetcode id=20 lang=golang
+ *
+ * [20] Valid Parentheses
+ */
+package code
+
+import (
+	"errors"
+	"fmt"
+)
+
+/*
+❌案1 : これでは要件を満たせられない
+左から一文字ずつ確認し、かっこの始まりを検知したら同じ種類の閉じるを末尾まで検索する
+最終的に閉じられてないものがあれば falseとなる
+
+案2
+左から一文字ずつ確認し、括弧の開始があればスタックに積み、括弧の閉じるを検知した時、スタックに積まれた始まりと種別が一致しているかで判定する
+*/
+
+// @lc code=start
+
+// かっこの種別
+// type BracketType int
+
+// const (
+// 	None          BracketType = iota // どの括弧にもマッチしない
+// 	Parenthesis                      // ()
+// 	CurlyBrace                       // {}
+// 	SquareBracket                    // []
+// )
+
+// スタックを表す構造体
+type Stack struct {
+	elements []rune
+}
+
+// 新しいスタックを作成する関数
+func NewStack() *Stack {
+	return &Stack{elements: []rune{}}
+}
+
+// スタックに要素を追加する（push）
+func (s *Stack) Push(element rune) {
+	s.elements = append(s.elements, element)
+}
+
+// スタックから要素を取り出す（pop）
+func (s *Stack) Pop() (rune, error) {
+	if len(s.elements) == 0 {
+		return 0, errors.New("stack is empty")
+	}
+	lastIndex := len(s.elements) - 1
+	element := s.elements[lastIndex]
+	s.elements = s.elements[:lastIndex]
+	return element, nil
+}
+
+// スタックが空か判定
+func (s *Stack) isEmpty() bool {
+	return len(s.elements) == 0
+}
+
+// テスト対象
+func isValid(s string) bool {
+	runes := []rune(s)
+	brackets := NewStack()
+	for i := 0; i < len(runes); i++ {
+		if isOpened(runes[i]) {
+			brackets.Push(runes[i])
+		} else if isClosed(runes[i]) {
+			if brackets.isEmpty() {
+				// 開始括弧が無い状態で閉じ括弧を検知した場合はその時点で不正となる
+				return false
+			}
+			openingBracket, err := brackets.Pop()
+			if err != nil {
+				fmt.Println(err)
+				return false
+			}
+			closer, err := getCloser(openingBracket)
+			if err != nil {
+				fmt.Println(err)
+				return false
+			}
+
+			if runes[i] != closer {
+				// 開始括弧と一致しない
+				return false
+			}
+		}
+	}
+
+	return brackets.isEmpty()
+}
+
+// isOpen 開始括弧かを判定
+func isOpened(r rune) bool {
+	return r == '(' || r == '{' || r == '['
+}
+
+// isClosed 閉じ括弧かを判定
+func isClosed(r rune) bool {
+	return r == ')' || r == '}' || r == ']'
+}
+
+// 開始括弧に対応した閉じ括弧を取得
+func getCloser(opening rune) (rune, error) {
+	switch opening {
+	case '(':
+		return ')', nil
+	case '{':
+		return '}', nil
+	case '[':
+		return ']', nil
+	default:
+		return 0, errors.New("invalid opening bracket")
+	}
+}
+
+// @lc code=end

--- a/code/easy_20_valid_parentheses_test.go
+++ b/code/easy_20_valid_parentheses_test.go
@@ -1,0 +1,41 @@
+/*
+ * @lc app=leetcode id=20 lang=golang
+ *
+ * [20] Valid Parentheses
+ */
+package code
+
+import "testing"
+
+func Test_isValid(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "OK1",
+			args: args{
+				s: "()",
+			},
+			want: true,
+		},
+		{
+			name: "開始括弧のみ",
+			args: args{
+				s: "(",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValid(tt.args.s); got != tt.want {
+				t.Errorf("isValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/code/easy_21_merge_two_sorted_lists.go
+++ b/code/easy_21_merge_two_sorted_lists.go
@@ -1,0 +1,56 @@
+/*
+ * @lc app=leetcode id=21 lang=golang
+ *
+ * [21] Merge Two Sorted Lists
+ */
+package code
+
+type ListNode struct {
+	Val  int
+	Next *ListNode
+}
+
+// @lc code=start
+/**
+ * Definition for singly-linked list.
+ * type ListNode struct {
+ *     Val int
+ *     Next *ListNode
+ * }
+ */
+
+func mergeTwoLists(list1 *ListNode, list2 *ListNode) *ListNode {
+	if list1 == nil {
+		return list2
+	} else if list2 == nil {
+		return list1
+	}
+
+	return recursiveMerge(list1, list2)
+}
+
+// 再起的にマージする
+func recursiveMerge(current *ListNode, next *ListNode) *ListNode {
+	var mergedList *ListNode
+	var newCurrent *ListNode
+	var newNext *ListNode
+	if current.Val <= next.Val {
+		mergedList = current
+		newCurrent = next
+		newNext = current
+	} else {
+		mergedList = next
+		newCurrent = current
+		newNext = next
+	}
+
+	if newNext.Next != nil {
+		mergedList.Next = recursiveMerge(newCurrent, newNext.Next)
+	} else {
+		mergedList.Next = newCurrent
+	}
+
+	return mergedList
+}
+
+// @lc code=end

--- a/code/easy_26_remove_duplicates_from_sorted_array.go
+++ b/code/easy_26_remove_duplicates_from_sorted_array.go
@@ -1,0 +1,48 @@
+/*
+ * @lc app=leetcode id=26 lang=golang
+ *
+ * [26] Remove Duplicates from Sorted Array
+ */
+package code
+
+/*
+メモ
+numsを別のスライスに置き換えると、アドレスが変わり呼び出し元で同じスライスを参照できなくなる。
+❌ nums = []int{1,2}
+問題の使用上
+nums[0] = 1
+nums[1] = 2
+といって方法で値を変えていく必要がある
+*/
+
+// @lc code=start
+func removeDuplicates(nums []int) int {
+	uniqueNums := uniqueInts(nums)
+
+	// 問題の仕様上、numsはソート済みのため、uniqueNumsを改めてソートしたりしない
+	// ただ、実際のプロダクトの処理的にはソートした方が良さそう
+
+	for i, num := range uniqueNums {
+		nums[i] = num
+	}
+
+	return len(uniqueNums)
+
+}
+
+// uniqueInts スライス内の整数をユニークな値にする
+func uniqueInts(nums []int) []int {
+	seen := make(map[int]bool)
+	var unique []int
+
+	for _, v := range nums {
+		if _, ok := seen[v]; !ok {
+			seen[v] = true
+			unique = append(unique, v)
+		}
+	}
+
+	return unique
+}
+
+// @lc code=end

--- a/code/easy_27_remove_element.go
+++ b/code/easy_27_remove_element.go
@@ -1,0 +1,25 @@
+/*
+ * @lc app=leetcode id=27 lang=golang
+ *
+ * [27] Remove Element
+ */
+
+package code
+
+// @lc code=start
+func removeElement(nums []int, val int) int {
+	var removiedNums []int
+	for i := 0; i < len(nums); i++ {
+		if nums[i] != val {
+			removiedNums = append(removiedNums, nums[i])
+		}
+	}
+
+	for i := 0; i < len(removiedNums); i++ {
+		nums[i] = removiedNums[i]
+	}
+
+	return len(removiedNums)
+}
+
+// @lc code=end

--- a/code/easy_28_find_the_index_of_the_first_occurrence_in_a_string.go
+++ b/code/easy_28_find_the_index_of_the_first_occurrence_in_a_string.go
@@ -1,0 +1,15 @@
+/*
+ * @lc app=leetcode id=28 lang=golang
+ *
+ * [28] Find the Index of the First Occurrence in a String
+ */
+package code
+
+import "strings"
+
+// @lc code=start
+func strStr(haystack string, needle string) int {
+	return strings.Index(haystack, needle)
+}
+
+// @lc code=end

--- a/code/easy_35_search_insert_position.go
+++ b/code/easy_35_search_insert_position.go
@@ -5,39 +5,28 @@
  */
 package code
 
+import "fmt"
+
 // @lc code=start
 func searchInsert(nums []int, target int) int {
-	return searchInsertRecursive(nums, target, 0)
+	return searchInsertRecursive(nums, target, 0, len(nums))
 }
 
-// 再起的にインサートするindexを見つけ返す
-func searchInsertRecursive(nums []int, target int, index int) int {
-	// 配列の長さが1の場合
-	if len(nums) == 1 {
-		if nums[0] < target {
-			// 配列の最後の値がtargetより大きい場合、配列の最後に追加するようにする
-			// if nums[1] < target {
-			// 	return index + 2
-			// }
-			return index + 1
-		} else {
-			return index
-		}
+func searchInsertRecursive(nums []int, target, start, end int) int {
+	fmt.Println("debug")
+	if start >= end {
+		return start
 	}
 
-	// 配列の番分の位置の数値を確認
-	var newNums []int
-	half := len(nums) / 2
-	if nums[half] == target {
-		return index + half
-	} else if nums[half] < target {
-		newNums = nums[half:]
-		index = index + half
+	mid := start + (end-start)/2
+	fmt.Println("hoge")
+	if nums[mid] == target {
+		return mid
+	} else if nums[mid] < target {
+		return searchInsertRecursive(nums, target, mid+1, end)
 	} else {
-		newNums = nums[:half]
+		return searchInsertRecursive(nums, target, start, mid)
 	}
-
-	return searchInsertRecursive(newNums, target, index)
 }
 
 // @lc code=end

--- a/code/easy_35_search_insert_position_test.go
+++ b/code/easy_35_search_insert_position_test.go
@@ -1,0 +1,55 @@
+package code
+
+import "testing"
+
+func Test_searchInsert(t *testing.T) {
+	type args struct {
+		nums   []int
+		target int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "一致するものがない場合",
+			args: args{
+				nums:   []int{1, 3, 5, 6},
+				target: 2,
+			},
+			want: 1,
+		},
+		{
+			name: "最後に挿入",
+			args: args{
+				nums:   []int{1, 3, 5, 6},
+				target: 7,
+			},
+			want: 4,
+		},
+		{
+			name: "先頭に挿入",
+			args: args{
+				nums:   []int{1},
+				target: 1,
+			},
+			want: 0,
+		},
+		{
+			name: "奇数numsで最後に一致",
+			args: args{
+				nums:   []int{1, 3, 5},
+				target: 5,
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := searchInsert(tt.args.nums, tt.args.target); got != tt.want {
+				t.Errorf("searchInsert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `searchInsert`関数のシグネチャが変更され、新しいパラメータ `start` と `end` が追加されました。これにより、再帰呼び出し時に配列の一部分を処理することができます。また、デバッグ用の `fmt.Println` ステートメントも追加されました。
- Test: `searchInsert`関数に対する新しいテストケースが追加されました。これにより、異なるシナリオでの関数の動作がカバーされます。

以上の変更が含まれています。


<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->